### PR TITLE
Set the CWD to the directory of the current file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "atom-linter": "^4.0.0",
     "atom-package-deps": "^4.0.1",
-    "stylint": "1.4.1"
+    "stylint": "1.3.10"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Sets the directory `stylint` is run in to that of the file currently being linted to allow it to attempt to grab its settings properly.

Fixes #27.