### PR TITLE
Update to stylint@1.4.1 and pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     }
   },
   "dependencies": {
-    "stylint": "^1.0.0",
     "atom-linter": "^4.0.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^4.0.1",
+    "stylint": "1.4.1"
   },
   "package-deps": [
     "linter"

--- a/spec/linter-stylint-spec.coffee
+++ b/spec/linter-stylint-spec.coffee
@@ -30,7 +30,7 @@ describe 'The stylint provider for Linter', ->
           expect(messages[0].type).toBeDefined()
           expect(messages[0].type).toEqual 'Warning'
           expect(messages[0].text).toBeDefined()
-          expect(messages[0].text).toEqual 'unecessary bracket'
+          expect(messages[0].text).toEqual 'unnecessary bracket'
           expect(messages[0].filePath).toBeDefined()
           expect(messages[0].filePath).toMatch(/.+bad\.styl$/)
           expect(messages[0].range).toBeDefined()


### PR DESCRIPTION
`stylint@^1.5.1` is broken with this codebase, this commit gets the package to a working version to base further fixes off of.