### PR TITLE
Fix "Error: Process exited with non-zero code"

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -101,6 +101,7 @@ export function provideLinter() {
       const options = {
         stdin: fileText,
         cwd: projectDir,
+        ignoreExitCode: true,
       };
 
       return helpers.execNode(executablePath, parameters, options).then(result => {

--- a/spec/fixtures/.stylintrc
+++ b/spec/fixtures/.stylintrc
@@ -1,3 +1,7 @@
 {
-    "brackets": "never"
+    "brackets": "never",
+    "colons": {
+      "expect": "never",
+      "error": true
+    }
 }

--- a/spec/fixtures/error.styl
+++ b/spec/fixtures/error.styl
@@ -1,0 +1,3 @@
+
+.test
+    color: red

--- a/spec/linter-stylint-spec.js
+++ b/spec/linter-stylint-spec.js
@@ -4,6 +4,7 @@ import path from 'path';
 
 const badPath = path.join(__dirname, 'fixtures', 'bad.styl');
 const goodPath = path.join(__dirname, 'fixtures', 'good.styl');
+const errorPath = path.join(__dirname, 'fixtures', 'error.styl');
 
 describe('The stylint provider for Linter', () => {
   const { lint } = require('../lib/init.js').provideLinter();
@@ -39,6 +40,21 @@ describe('The stylint provider for Linter', () => {
           expect(messages[0].html).not.toBeDefined();
           expect(messages[0].filePath).toBe(badPath);
           expect(messages[0].range).toEqual([[1, 5], [1, 7]]);
+        })
+      )
+    )
+  );
+
+  it('handles error-level severity', () =>
+    waitsForPromise(() =>
+      atom.workspace.open(errorPath).then(editor =>
+        lint(editor).then(messages => {
+          expect(messages.length).toEqual(1);
+          expect(messages[0].type).toBe('error');
+          expect(messages[0].text).toBe('unnecessary colon found (colons)');
+          expect(messages[0].html).not.toBeDefined();
+          expect(messages[0].filePath).toBe(errorPath);
+          expect(messages[0].range).toEqual([[2, 8], [2, 9]]);
         })
       )
     )


### PR DESCRIPTION
`stylint` returns an error code of 1 when there are fatal errors, which pops up when `.stylintrc` is set to treat linter errors as datal.

Related to https://github.com/steelbrain/atom-linter/issues/139