### PR TITLE
Fix race condition in marking results

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -105,6 +105,11 @@ export function provideLinter() {
       };
 
       return helpers.execNode(executablePath, parameters, options).then((result) => {
+        if (textEditor.getText() !== fileText) {
+          // Text has been modified since the initial call, tell Linter not to update results
+          return null;
+        }
+
         let match;
         // eslint-disable-next-line prefer-template
         const regex = new RegExp('' +


### PR DESCRIPTION
It's possible that the editor text gets modified after the lint was triggered, but before `stylint` returns results. As this situation can lead to invalid marker positions, discard the results as another `lint()` call will be triggered soon for the modifications anyway.

Fixes #48.