### PR TITLE
Handle custom reporters in the configuration

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -18,7 +18,8 @@ export const config = {
     type: 'string',
     default: path.join(__dirname, '..', 'node_modules', 'stylint', 'bin', 'stylint'),
     description: 'Full path to the `stylint` executable node script ' +
-      'file (e.g. /usr/local/bin/stylint)',
+      'file (e.g. /usr/local/bin/stylint). Note that `stylint-json-reporter` ' +
+      'must be installed in this node_modules folder.',
   },
   projectConfigFile: {
     type: 'string',
@@ -83,9 +84,9 @@ export function provideLinter() {
         return Promise.resolve([]);
       }
 
-      const parameters = [filePath];
+      const parameters = [filePath, '--reporter', 'stylint-json-reporter'];
 
-      if (onlyRunWhenConfig || (!runWithStrictMode && projectConfigPath !== null)) {
+      if (!runWithStrictMode && projectConfigPath !== null) {
         parameters.push('-c', projectConfigPath);
       }
 
@@ -111,36 +112,32 @@ export function provideLinter() {
           return null;
         }
 
-        let match;
-        // eslint-disable-next-line prefer-template
-        const regex = new RegExp('' +
-          /^(\d+)(?::(\d+))?\s+/.source + // Line, and potential column
-          '(?:' +
-            /(error|warning)\s+(.+?)\s+(\w+)\s*$/.source + // No configuration
-            '|' +
-            /(\w+)\s+(error|warning)\s+(.+)$/.source + // Configuration
-          ')'
-        , 'gm');
-        const messages = [];
-
-        match = regex.exec(result);
-        while (match !== null) {
-          const line = match[1] - 1;
-          const col = match[2] ? match[2] - 1 : undefined;
-          const type = match[3] ? match[3] : match[7];
-          const text = match[4] ? `${match[4]} (${match[5]})` : `${match[8]} (${match[6]})`;
-
-          messages.push({
-            type,
-            text,
-            filePath,
-            range: helpers.rangeFromLineNumber(textEditor, line, col),
-          });
-
-          match = regex.exec(result);
+        let data;
+        try {
+          data = JSON.parse(result)[0];
+        } catch (e) {
+          const message = 'Error parsing stylint output';
+          const msgOptions = {
+            description: 'Something went wrong parsing the stylint output, ' +
+              'please see the console for details.',
+          };
+          atom.notifications.addError(message, msgOptions);
+          // eslint-disable-next-line no-console
+          console.error('linter-stylint: Failed to parse output as JSON', result);
+          return null;
         }
 
-        return messages;
+        return data.messages.reduce((prev, curr) =>
+          prev.concat([{
+            type: curr.severity,
+            text: `${curr.message} (${curr.rule})`,
+            filePath,
+            range: helpers.rangeFromLineNumber(textEditor,
+              curr.line - 1,
+              curr.column !== -1 ? curr.column - 1 : undefined
+            ),
+          }])
+        , []);
       });
     },
   };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
-    "stylint": "1.5.6"
+    "stylint": "1.5.6",
+    "stylint-json-reporter": "^0.3.1"
   },
   "devDependencies": {
     "eslint": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "devDependencies": {
     "eslint": "^3.6.1",
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^1.16.0"
+    "eslint-plugin-import": "^1.16.0",
+    "stylint-stylish": "^1.3.3"
   },
   "eslintConfig": {
     "rules": {

--- a/spec/fixtures/custom-reporter/.stylintrc
+++ b/spec/fixtures/custom-reporter/.stylintrc
@@ -1,0 +1,7 @@
+{
+  "reporter": "stylint-stylish",
+  "colons": {
+    "expect": "never",
+    "error": true
+  }
+}

--- a/spec/fixtures/custom-reporter/reporter.styl
+++ b/spec/fixtures/custom-reporter/reporter.styl
@@ -1,0 +1,2 @@
+.test
+  color: red

--- a/spec/linter-stylint-spec.js
+++ b/spec/linter-stylint-spec.js
@@ -11,19 +11,19 @@ const reporterPath = path.join(__dirname, 'fixtures', 'custom-reporter', 'report
 const validateMulti = (messages, filePath) => {
   expect(messages.length).toBe(3);
 
-  expect(messages[0].type).toBe('warning');
+  expect(messages[0].type).toBe('Warning');
   expect(messages[0].text).toBe('unnecessary bracket (brackets)');
   expect(messages[0].html).not.toBeDefined();
   expect(messages[0].filePath).toBe(filePath);
   expect(messages[0].range).toEqual([[0, 5], [0, 7]]);
 
-  expect(messages[1].type).toBe('warning');
+  expect(messages[1].type).toBe('Warning');
   expect(messages[1].text).toBe('missing colon between property and value (colons)');
   expect(messages[1].html).not.toBeDefined();
   expect(messages[1].filePath).toBe(filePath);
   expect(messages[1].range).toEqual([[1, 4], [1, 7]]);
 
-  expect(messages[2].type).toBe('warning');
+  expect(messages[2].type).toBe('Warning');
   expect(messages[2].text).toBe('unnecessary bracket (brackets)');
   expect(messages[2].html).not.toBeDefined();
   expect(messages[2].filePath).toBe(filePath);

--- a/spec/linter-stylint-spec.js
+++ b/spec/linter-stylint-spec.js
@@ -6,6 +6,7 @@ const multiPath = path.join(__dirname, 'fixtures', 'multi', 'multi.styl');
 const noConfigMultiPath = path.join(__dirname, 'fixtures', 'no-config-multi', 'multi.styl');
 const goodPath = path.join(__dirname, 'fixtures', 'good', 'good.styl');
 const errorPath = path.join(__dirname, 'fixtures', 'error', 'error.styl');
+const reporterPath = path.join(__dirname, 'fixtures', 'custom-reporter', 'reporter.styl');
 
 const validateMulti = (messages, filePath) => {
   expect(messages.length).toBe(3);
@@ -79,6 +80,14 @@ describe('The stylint provider for Linter', () => {
       )
     );
   });
+
+  it('works when custom reporters are specified in the configuration', () =>
+    waitsForPromise(() =>
+      atom.workspace.open(reporterPath).then(editor =>
+        lint(editor).then(messages => validateError(messages, reporterPath))
+      )
+    )
+  );
 
   it('handles error-level severity', () =>
     waitsForPromise(() =>

--- a/spec/linter-stylint-spec.js
+++ b/spec/linter-stylint-spec.js
@@ -29,6 +29,15 @@ const validateMulti = (messages, filePath) => {
   expect(messages[2].range).toEqual([[2, 0], [2, 1]]);
 };
 
+const validateError = (messages, filePath) => {
+  expect(messages.length).toEqual(1);
+  expect(messages[0].type).toBe('Error');
+  expect(messages[0].text).toBe('unnecessary colon found (colons)');
+  expect(messages[0].html).not.toBeDefined();
+  expect(messages[0].filePath).toBe(filePath);
+  expect(messages[0].range).toEqual([[1, 6], [1, 7]]);
+};
+
 describe('The stylint provider for Linter', () => {
   const { lint } = require('../lib/init.js').provideLinter();
 
@@ -74,14 +83,7 @@ describe('The stylint provider for Linter', () => {
   it('handles error-level severity', () =>
     waitsForPromise(() =>
       atom.workspace.open(errorPath).then(editor =>
-        lint(editor).then((messages) => {
-          expect(messages.length).toEqual(1);
-          expect(messages[0].type).toBe('error');
-          expect(messages[0].text).toBe('unnecessary colon found (colons)');
-          expect(messages[0].html).not.toBeDefined();
-          expect(messages[0].filePath).toBe(errorPath);
-          expect(messages[0].range).toEqual([[1, 6], [1, 7]]);
-        })
+        lint(editor).then(messages => validateError(messages, errorPath))
       )
     )
   );


### PR DESCRIPTION
Force the usage of the `stylint-json-reporter` reporter in the output, overriding any reporters specified in the configuration file of the file being linted.

Fixes #65.