### PR TITLE
Disable lintOnFly

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -68,7 +68,7 @@ export function provideLinter() {
       'source.stylus', 'source.styl', 'source.css.styl', 'source.css.stylus',
     ],
     scope: 'file',
-    lintOnFly: true,
+    lintOnFly: false,
     lint: (textEditor) => {
       const filePath = textEditor.getPath();
       const fileText = textEditor.getText();
@@ -101,14 +101,17 @@ export function provideLinter() {
       }
 
       const options = {
-        stdin: fileText,
         cwd: projectDir,
         ignoreExitCode: true,
       };
 
       return helpers.execNode(executablePath, parameters, options).then((result) => {
         if (textEditor.getText() !== fileText) {
-          // Text has been modified since the initial call, tell Linter not to update results
+          // eslint-disable-next-line no-console
+          console.warn('linter-stylint:: The file was modified since the ' +
+            'request was sent to check it. Since any results would no longer ' +
+            'be valid, they are not being updated. Please save the file ' +
+            'again to update the results.');
           return null;
         }
 


### PR DESCRIPTION
It turns out `stylint` doesn't actually support linting contents from `stdin`. The fact that this was working at all is a complete coincidence of the working directory being set.