### PR TITLE
Always use file directory as CWD

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -87,21 +87,11 @@ export function provideLinter() {
       const parameters = [filePath, '--reporter', 'stylint-json-reporter'];
 
       if (!runWithStrictMode && projectConfigPath !== null) {
-        parameters.push('-c', projectConfigPath);
-      }
-
-      let projectDir;
-      // Attempt to use Atom's project folder for the CWD
-      if (projectConfigPath === null) {
-        projectDir = atom.project.relativizePath(filePath)[0];
-      }
-      // Fall back to the file directory if Atom wasn't opened as a project
-      if (projectDir === null) {
-        projectDir = path.dirname(filePath);
+        parameters.push('--config', projectConfigPath);
       }
 
       const options = {
-        cwd: projectDir,
+        cwd: path.dirname(filePath),
         ignoreExitCode: true,
       };
 


### PR DESCRIPTION
Stylint's config resolution is based on being ran from the directory of the file itself. Since the initial bug where it required a `package.json` has long been fixed, go back to using the file's directory.