### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,15 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "linter"
   ],
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "test": "apm test",
     "lint": "eslint ."
   },
@@ -38,6 +39,12 @@
     "stylint-json-reporter": "^0.3.1"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
@@ -62,5 +69,13 @@
     "env": {
       "node": true
     }
+  },
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
